### PR TITLE
Add tool execution support to LocalAgent

### DIFF
--- a/agent/core.py
+++ b/agent/core.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, List
 
+from agent.tools import EchoTool
+
 import yaml
 
 
@@ -37,6 +39,9 @@ class LocalAgent:
         # very short‑term memory buffer (ordered list of strings)
         self.memory: List[str] = []
 
+        # available tools by name
+        self.tools = {"echo": EchoTool()}
+
     # ------------------------------------------------------------------
     # Placeholder interfaces
     # ------------------------------------------------------------------
@@ -49,7 +54,9 @@ class LocalAgent:
     def run_tool(self, name: str, input: str) -> str:
         """Execute a tool by name with the given input.
 
-        This is currently a stub and always returns ``"Tool executed"``.
+        Look up the tool by ``name`` and run it with ``input`` if available.
         """
-        _ = name, input
-        return "Tool executed"
+        tool = self.tools.get(name)
+        if tool is None:
+            return "Tool not found"
+        return tool.run(input)


### PR DESCRIPTION
## Summary
- import `EchoTool` in the simple agent
- create a `self.tools` dictionary during initialization
- implement looking up and running tools in `run_tool`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846d31fa9d8832a9f440e011fc5798f