### PR TITLE
Add chat & tool CLI commands

### DIFF
--- a/llm-agent/cli.py
+++ b/llm-agent/cli.py
@@ -1,13 +1,28 @@
-"""Command-line interface placeholder."""
+"""Command line interface for interacting with the agent."""
 
+from agent.core import LocalAgent
 import typer
 
-app = typer.Typer()
+app = typer.Typer(help="Interact with the local agent")
+
 
 @app.command()
-def main():
-    """Run the agent."""
-    typer.echo("Agent starting...")
+def chat(text: str) -> None:
+    """Send ``text`` to the agent and print the response."""
+
+    agent = LocalAgent()
+    response = agent.process_input(text)
+    typer.echo(response)
+
+
+@app.command()
+def tool(name: str, input: str) -> None:
+    """Run a tool by ``name`` with ``input`` and print the result."""
+
+    agent = LocalAgent()
+    result = agent.run_tool(name, input)
+    typer.echo(result)
+
 
 if __name__ == "__main__":
     app()


### PR DESCRIPTION
## Summary
- expose LocalAgent via the command line
- implement `chat` to process user input
- implement `tool` to run named tools

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846d44caeac832a9692677622996f28