### PR TITLE
Add FastAPI main entry point

### DIFF
--- a/llm-agent/main.py
+++ b/llm-agent/main.py
@@ -1,0 +1,9 @@
+from fastapi import FastAPI
+from server.api import router
+
+app = FastAPI()
+app.include_router(router)
+
+@app.get('/health')
+async def health() -> dict[str, str]:
+    return {"status": "ok"}


### PR DESCRIPTION
## Summary
- add `main.py` for launching FastAPI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846d9b18148832a89a4d907e2741c21