### PR TITLE
Add PDF download tool

### DIFF
--- a/agent/core.py
+++ b/agent/core.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, List
 
-from agent.tools import EchoTool
+from agent.tools import EchoTool, PaperDownloadTool
 
 import yaml
 
@@ -40,7 +40,10 @@ class LocalAgent:
         self.memory: List[str] = []
 
         # available tools by name
-        self.tools = {"echo": EchoTool()}
+        self.tools = {
+            "echo": EchoTool(),
+            "download_papers": PaperDownloadTool(),
+        }
 
     # ------------------------------------------------------------------
     # Placeholder interfaces

--- a/llm-agent/tests/test_tools.py
+++ b/llm-agent/tests/test_tools.py
@@ -1,4 +1,47 @@
 """Tests for tools placeholder."""
 
+import sys
+from pathlib import Path
+from unittest.mock import Mock
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from agent.tools import PaperDownloadTool
+
+
 def test_placeholder():
     assert True
+
+
+def test_paper_download_tool(monkeypatch, tmp_path):
+    """Ensure PDFs are saved when the API returns results."""
+
+    tool = PaperDownloadTool()
+
+    # fake search response
+    def fake_get(url, params=None, timeout=10):
+        mock_resp = Mock()
+        if "paper/search" in url:
+            mock_resp.status_code = 200
+            mock_resp.json.return_value = {
+                "data": [
+                    {"title": "Paper One", "openAccessPdf": {"url": "http://pdf1"}},
+                    {"title": "Paper Two", "openAccessPdf": {"url": "http://pdf2"}},
+                ]
+            }
+            mock_resp.raise_for_status = lambda: None
+            return mock_resp
+        else:
+            mock_resp.status_code = 200
+            mock_resp.content = b"%PDF-1.4"
+            mock_resp.raise_for_status = lambda: None
+            mock_resp.ok = True
+            return mock_resp
+
+    monkeypatch.setattr("requests.get", fake_get)
+    monkeypatch.setenv("PAPERS_DIR", str(tmp_path))
+
+    result = tool.run("test query")
+    files = list(tmp_path.glob("*.pdf"))
+    assert len(files) == 2
+    assert result.startswith("Downloaded:")


### PR DESCRIPTION
## Summary
- implement a `PaperDownloadTool` for fetching PDFs from Semantic Scholar
- register new tool with `LocalAgent`
- add tests for the PDF tool

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846db464a14832aa6ca2fee3bf86931