### PR TITLE
Add PDFExtractTool

### DIFF
--- a/agent/core.py
+++ b/agent/core.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, List
 
-from agent.tools import EchoTool, PaperDownloadTool
+from agent.tools import EchoTool, PaperDownloadTool, PDFExtractTool
 
 import yaml
 
@@ -43,6 +43,7 @@ class LocalAgent:
         self.tools = {
             "echo": EchoTool(),
             "download_papers": PaperDownloadTool(),
+            "pdf_extract": PDFExtractTool(),
         }
 
     # ------------------------------------------------------------------

--- a/agent/tools.py
+++ b/agent/tools.py
@@ -91,3 +91,30 @@ class PaperDownloadTool(Tool):
             return "No PDFs downloaded"
 
         return "Downloaded: " + ", ".join(downloaded)
+
+
+class PDFExtractTool(Tool):
+    """Extract all text content from a PDF file."""
+
+    name = "pdf_extract"
+    description = "Extract and return text from a PDF given its file path"
+
+    def run(self, input: str) -> str:
+        from pathlib import Path
+        import fitz  # PyMuPDF
+
+        path = Path(input.strip())
+        if not path.is_file():
+            return "File not found"
+
+        try:
+            doc = fitz.open(path)
+        except Exception as exc:
+            return f"Failed to open PDF: {exc}"
+
+        texts: list[str] = []
+        for page in doc:
+            texts.append(page.get_text())
+        doc.close()
+
+        return "\n".join(texts)

--- a/llm-agent/tests/test_tools.py
+++ b/llm-agent/tests/test_tools.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock
 
 sys.path.append(str(Path(__file__).resolve().parents[2]))
 
-from agent.tools import PaperDownloadTool
+from agent.tools import PaperDownloadTool, PDFExtractTool
 
 
 def test_placeholder():
@@ -45,3 +45,21 @@ def test_paper_download_tool(monkeypatch, tmp_path):
     files = list(tmp_path.glob("*.pdf"))
     assert len(files) == 2
     assert result.startswith("Downloaded:")
+
+
+def test_pdf_extract_tool(tmp_path):
+    """Ensure text is extracted from a PDF file."""
+
+    tool = PDFExtractTool()
+
+    import fitz
+
+    pdf_path = tmp_path / "sample.pdf"
+    doc = fitz.open()
+    page = doc.new_page()
+    page.insert_text((72, 72), "hello world")
+    doc.save(pdf_path)
+    doc.close()
+
+    result = tool.run(str(pdf_path))
+    assert "hello world" in result


### PR DESCRIPTION
## Summary
- add `PDFExtractTool` to extract PDF text with PyMuPDF
- register `pdf_extract` tool in `LocalAgent`
- test extracting text from a generated PDF

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846dde9ba84832aab78dfd5257ff428